### PR TITLE
Add theme toggle button for switching between light and dark modes

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,6 +17,7 @@
         <a href="index.html">Home</a>
         <a href="about.html">About Us</a>
         <a href="contact.html">Contact Us</a>
+        <button id="theme-toggle" class="nav-button">Toggle Theme</button>
       </div>
     </div>
 
@@ -45,4 +46,5 @@
     
 </body>
 <script src="src/about.js"></script>
+<script src="src/theme.js"></script>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -17,6 +17,7 @@
             <a href="index.html">Home</a>
             <a href="about.html">About Us</a>
             <a href="contact.html">Contact Us</a>
+            <button id="theme-toggle" class="nav-button">Toggle Theme</button>
         </div>
     </div>
 
@@ -61,5 +62,6 @@
 
     <script src="https://cdn.emailjs.com/dist/email.min.js"></script>
     <script src="contact.js"></script>
+    <script src="src/theme.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <a href="index.html">Home</a>
       <a href="about.html">About Us</a>
       <a href="contact.html">Contact Us</a>
+      <button id="theme-toggle" class="nav-button">Toggle Theme</button>
     </div>
   </div>
     <main>
@@ -93,5 +94,6 @@
         </div>
       </div>
   </footer>
+  <script src="src/theme.js"></script>
   </body>
 </html>

--- a/newstyle.css
+++ b/newstyle.css
@@ -1,7 +1,5 @@
 /* Reset some default styles */
 
-
-
 .nav-button {
   background: #007bff; /* Blue background for buttons */
   color: white;
@@ -90,9 +88,38 @@ button:active {
   transform: translateY(0); /* Reset lift on click */
 }
 
-/* footer {
-  text-align: center;
-  margin-top: 2rem;
-  color: #666;
-  font-size: 0.9rem;
-} */
+/* Dark Mode Styles */
+body.dark-mode {
+  background-color: #121212; /* Dark background */
+  color: #e0e0e0; /* Light text for readability */
+}
+
+body.dark-mode .navbar {
+  background: #333; /* Dark background for navbar */
+}
+
+body.dark-mode .box {
+  background: #1e1e1e; /* Dark card background */
+  border: 1px solid #444; /* Darker border */
+}
+
+body.dark-mode input[type="text"],
+body.dark-mode input[type="email"],
+body.dark-mode textarea {
+  border: 2px solid #00aaff; /* Light blue border for inputs */
+}
+
+body.dark-mode input[type="text"]:focus,
+body.dark-mode input[type="email"]:focus,
+body.dark-mode textarea:focus {
+  border-color: #00bfff; /* Brighter focus border */
+  box-shadow: 0 0 5px rgba(0, 169, 255, 0.5); /* Subtle glow effect on focus */
+}
+
+body.dark-mode button {
+  background: #0056b3; /* Darker blue for buttons */
+}
+
+body.dark-mode button:hover {
+  background: #007bff; /* Brighter blue on hover */
+}

--- a/src/about.css
+++ b/src/about.css
@@ -1,7 +1,7 @@
-
 h1 {
     text-align: center;
 }
+
 .contributors-container {
     display: flex;
     flex-wrap: wrap;
@@ -9,34 +9,40 @@ h1 {
     gap: 20px;
     padding: 20px;
 }
+
 .card {
-    background-color: white;
+    background-color: white; /* Light mode background */
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     width: 300px;
-    height:300px;
+    height: 300px;
     text-align: center;
     padding: 20px;
 }
+
 .card img {
     border-radius: 10%;
     width: 60%;
     height: 80%;
 }
+
 .card h3 {
     margin: 10px 0;
     font-size: 18px;
     color: #0056b3;
 }
-.card h4{
+
+.card h4 {
     color: #0056b3;
 }
+
 .card a {
     text-decoration: none;
     color: #007bff;
     font-weight: bold;
     font-size: 12px;
 }
+
 .card a:hover {
     color: #0056b3;
 }
@@ -51,7 +57,7 @@ h1 {
     width: 100%;
     max-width: 400px;
     padding: 10px;
-    border: 1px solid #007bff;
+    border: 1px solid #007bff; /* Light mode border */
     border-radius: 5px;
     font-size: 16px;
     outline: none;
@@ -59,11 +65,47 @@ h1 {
 }
 
 #search-input:focus {
-    border-color: #0056b3;
+    border-color: #0056b3; /* Light mode focus border */
 }
 
+/* Dark Mode Styles */
+body.dark-mode {
+    background-color: #121212; /* Dark background */
+    color: #ffffff; /* Light text */
+}
+
+body.dark-mode .card {
+    background-color: #1e1e1e; /* Dark card background */
+    border: 1px solid #444; /* Darker border */
+}
+
+body.dark-mode .card h3,
+body.dark-mode .card h4 {
+    color: #bb86fc; /* Light purple for headings */
+}
+
+body.dark-mode .card a {
+    color: #bb86fc; /* Light purple for links */
+}
+
+body.dark-mode .search-container {
+    color: #ffffff; /* Light text in search container */
+}
+
+body.dark-mode #search-input {
+    border: 1px solid #bb86fc; /* Dark mode border for search input */
+    background-color: #1e1e1e; /* Dark background for input */
+    color: #ffffff; /* Light text for input */
+}
+
+body.dark-mode #search-input:focus {
+    border-color: #6200ee; /* Dark mode focus border color */
+}
+
+/* Responsive Design */
 @media (max-width: 600px) {
     #search-input {
         max-width: 90%;
     }
 }
+

--- a/src/navbar.css
+++ b/src/navbar.css
@@ -1,23 +1,38 @@
 .navbar {
-    background-color: #deedf7;
+    background-color: #deedf7; /* Light mode background */
     overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 10px 20px;
     font-size: 20px;
-    color:#3498db;
+    color: #3498db; /* Light mode text color */
     /* z-index: 10; */
-  }
-  
-  .navbar a {
+}
+
+body.dark-mode .navbar {
+    background-color: #333; /* Dark mode background */
+    color: #deedf7; /* Dark mode text color */
+}
+
+.navbar a {
     float: left;
     display: block;
     /* color: blue; */
     text-align: center;
     padding: 14px 20px;
     text-decoration: none;
-  }
-  .navbar>.links{
+    color: #3498db; /* Light mode link color */
+}
+
+body.dark-mode .navbar a {
+    color: #deedf7; /* Dark mode link color */
+}
+
+.navbar > .links {
     font-size: 16px;
-  }
+}
+
+body.dark-mode .navbar > .links {
+    color: #deedf7; /* Dark mode link color for .links */
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,22 +1,22 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
+
 * {
   padding: 0;
   margin: 0;
   box-sizing: border-box;
 }
+
 body {
   font-size: 62.5%;
   font-family: 'Roboto', sans-serif;
   background: url('../src/quizz.jpg');
   background-position: center;
   background-size: cover;
-  /* display: flex; */
-  /* justify-content: center; */
-  /* align-items: center; */
   height: 100vh;
   color: #fff;
   position: relative;
 }
+
 main::before {
   content: '';
   position: absolute;
@@ -27,6 +27,7 @@ main::before {
   background: rgba(0, 0, 0, 0.5);
   z-index: 1;
 }
+
 main {
   width: 100%;
   height: 100%;
@@ -36,31 +37,41 @@ main {
   position: relative;
   z-index: 2; /* Place main content above the overlay */
 }
+
 .box {
-  background-color: #fff;
+  background-color: #fff; /* Light mode background */
   width: 90%;
   max-width: 500px;
   padding: 25px;
   border-radius: 10px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
   text-align: left;
-  color: #333;
+  color: #333; /* Light mode text color */
   z-index: 3;
 }
+
+body.dark-mode .box {
+  background-color: #333; /* Dark mode background */
+  color: #fff; /* Dark mode text color */
+}
+
 .Ques {
   font-size: 1.8rem;
   font-weight: 500;
   margin-bottom: 20px;
 }
+
 .row {
   font-size: 1.2rem;
   margin: 15px 0;
   display: flex;
   align-items: center;
 }
+
 .options {
   margin-right: 10px;
 }
+
 .btn {
   outline: none;
   width: 100%;
@@ -76,11 +87,12 @@ main {
   margin-top: 20px;
   width: calc(50% - 10px);
 }
+
 .btn2 {
   outline: none;
   width: 100%;
   font-size: 1.4rem;
-  background-color: #3498db;;
+  background-color: #3498db;
   border: none;
   border-radius: 25px;
   font-weight: 500;
@@ -91,34 +103,41 @@ main {
   margin-top: 20px;
   width: calc(50% - 10px);
 }
+
 .btn:hover {
   background-color: #2980b9;
 }
+
 .btn2:hover {
   background-color: #2980b9;
 }
+
 .head {
   font-size: 2rem;
   margin: 20px;
-  /* height: 300px; */
 }
+
 .marks {
   font-size: 1.5rem;
   margin: 50px;
 }
+
 .result {
   font-size: 2rem;
   text-align: center;
 }
+
 .again {
   margin-top: 20px;
   width: 100%;
   position: static;
   display: inline-block;
 }
+
 .hidden {
   display: none;
 }
+
 .copyRight {
   font-size: 0.8rem;
   position: absolute;
@@ -127,6 +146,7 @@ main {
   width: 100%;
   color: #e2dfdf;
 }
+
 /* Responsive design adjustments */
 @media screen and (max-width: 768px) {
   .box {
@@ -182,4 +202,39 @@ main {
   border-radius: 25px; 
   transition: width 0.3s ease; 
 }
+#theme-toggle {
+    background-color: #007bff; /* Change this to the desired background color */
+    color: white; /* Text color */
+    padding: 10px 20px; /* Vertical and horizontal padding */
+    border: none; /* No border */
+    border-radius: 5px; /* Rounded corners */
+    font-size: 16px; /* Font size */
+    cursor: pointer; /* Pointer cursor on hover */
+    transition: background-color 0.3s ease; /* Smooth transition for background color */
+}
 
+/* Add hover effect */
+#theme-toggle:hover {
+    background-color: #0056b3; /* Darker shade for hover effect */
+}
+
+/* Active state effect */
+#theme-toggle:active {
+    background-color: #004085; /* Even darker shade for active state */
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    #theme-toggle {
+        font-size: 14px; /* Smaller font on mobile */
+        padding: 8px 16px; /* Adjust padding on mobile */
+    }
+}
+
+/* Responsive adjustments for larger screens */
+@media (min-width: 601px) {
+    #theme-toggle {
+        font-size: 16px; /* Back to normal font size */
+        padding: 10px 20px; /* Back to normal padding */
+    }
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,16 @@
+// theme.js
+(function () {
+    // Check local storage for theme preference
+    const currentTheme = localStorage.getItem('theme');
+    if (currentTheme === 'dark') {
+        document.body.classList.add('dark-mode'); // Add dark mode class if set
+    }
+
+    // Toggle theme on button click
+    document.getElementById('theme-toggle').addEventListener('click', function () {
+        const isDarkMode = document.body.classList.toggle('dark-mode');
+        // Save the preference in local storage
+        localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
+    });
+})();
+


### PR DESCRIPTION
## Related Issue
Fixes #22

## Description
The quiz app used to have only one theme. This update adds a button that lets users easily switch between dark and light modes by clicking it. This improves accessibility and makes the app more user-friendly. The theme preference is saved in local storage, so it stays the same even when the user comes back later.



## Changes Made
- Added a toggle button for light/dark mode.
- Updated CSS for both themes.
- Implemented local storage for theme preferences.

## Screenshots

### Home Page
- **Light Mode**:
![home-light](https://github.com/user-attachments/assets/43ae5380-b361-4f7e-8991-083cc9f41de2)


- **Dark Mode**:
![home-dark](https://github.com/user-attachments/assets/45da2e6c-a8b9-4965-ae61-d2fabb11e542)


### About Us
- **Light Mode**:
![Screenshot 2024-10-18 233303](https://github.com/user-attachments/assets/113918f1-ef76-4b0a-9046-4cc5f226c8cf)



- **Dark Mode**:
![Screenshot 2024-10-18 233252](https://github.com/user-attachments/assets/fa590601-b420-4131-af8b-fa9b454d38d7)



### Contact Us
- **Light Mode**:
![contact us - light](https://github.com/user-attachments/assets/9ac36f45-224f-432f-9ed0-83426cab60ba)


- **Dark Mode**:
![contact us - dark](https://github.com/user-attachments/assets/fd8eca1e-9de9-4a59-93f2-ed359a7517c1)

